### PR TITLE
Add helper for parsing RFC2253 Distinguished Names

### DIFF
--- a/esteid/digidocservice/containers.py
+++ b/esteid/digidocservice/containers.py
@@ -104,7 +104,7 @@ class BdocContainer(object):
         try:
             return buf, ZipFile(buf, 'a')
 
-        except:
+        except Exception:
             raise BDOCException('ZipArchive could not be opened')
 
     def hash_codes_format(self):

--- a/esteid/helpers.py
+++ b/esteid/helpers.py
@@ -1,9 +1,19 @@
 import re
+import sys
+
+from six import unichr
 
 
 def ucs_to_utf8(val):
-    return bytes([ord(x) for x in re.sub(r"\\([0-9ABCDEF]{1,2})",
-                                         lambda x: chr(int(x.group(1), 16)), val)]).decode('utf-8')
+    klass = bytes
+
+    # For py2:
+    #  - bytes is an alias for str: use bytearray instead
+    if sys.version_info[0] < 3:
+        klass = bytearray
+
+    return klass([ord(x) for x in re.sub(r"\\([0-9ABCDEF]{1,2})",
+                                         lambda x: unichr(int(x.group(1), 16)), val)]).decode('utf-8')
 
 
 def get_name_from_legacy_common_name(common_name):
@@ -47,6 +57,6 @@ def parse_rfc_dn(dn):
             res[l] = part[1]
 
         elif l:
-            res[l] = '{0},{1}'.format(res[l], part)
+            res[l] = u'{0},{1}'.format(res[l], part)
 
     return res

--- a/esteid/helpers.py
+++ b/esteid/helpers.py
@@ -1,0 +1,52 @@
+import re
+
+
+def ucs_to_utf8(val):
+    return bytes([ord(x) for x in re.sub(r"\\([0-9ABCDEF]{1,2})",
+                                         lambda x: chr(int(x.group(1), 16)), val)]).decode('utf-8')
+
+
+def get_name_from_legacy_common_name(common_name):
+    common_name = common_name.replace('\\,', ',')
+    common_name = common_name.strip().rstrip(',')
+
+    parts = common_name.split(',')[:-1]
+    parts.reverse()
+
+    return ' '.join(parts).title()
+
+
+def get_id_from_legacy_common_name(common_name):
+    common_name = common_name.strip().rstrip(',')
+
+    return common_name.split(',')[-1]
+
+
+def parse_legacy_dn(dn):
+    x_client = dn.strip().strip('/').split('/')
+
+    res = {}
+
+    for part in x_client:
+        part = ucs_to_utf8(part).split('=')
+        res[part[0]] = part[1]
+
+    return res
+
+
+def parse_rfc_dn(dn):
+    dn = ucs_to_utf8(dn).replace('\,', ',')
+    res = {}
+    l = None
+
+    for part in dn.strip().split(','):
+        if '=' in part:
+            part = part.split('=')
+
+            l = part[0]
+            res[l] = part[1]
+
+        elif l:
+            res[l] = '{0},{1}'.format(res[l], part)
+
+    return res

--- a/esteid/helpers.py
+++ b/esteid/helpers.py
@@ -47,16 +47,16 @@ def parse_legacy_dn(dn):
 def parse_rfc_dn(dn):
     dn = ucs_to_utf8(dn).replace('\,', ',')
     res = {}
-    l = None
+    c_key = None
 
     for part in dn.strip().split(','):
         if '=' in part:
             part = part.split('=')
 
-            l = part[0]
-            res[l] = part[1]
+            c_key = part[0]
+            res[c_key] = part[1]
 
-        elif l:
-            res[l] = u'{0},{1}'.format(res[l], part)
+        elif c_key:
+            res[c_key] = u'{0},{1}'.format(res[c_key], part)
 
     return res

--- a/esteid/middleware.py
+++ b/esteid/middleware.py
@@ -1,5 +1,3 @@
-import re
-
 from django.utils.cache import patch_vary_headers
 
 from esteid.helpers import parse_legacy_dn

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ DJANGO_SETTINGS_MODULE=test_settings
 django_find_project=false
 python_files=tests/*.py tests/**/*.py
 norecursedirs=venv* dist* htmlcov* .tox*
-addopts=--capture=no --strict
+addopts=--strict

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [flake8]
-max-line-length = 119
+max-line-length = 140

--- a/tests/common_name.py
+++ b/tests/common_name.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from esteid.helpers import get_name_from_legacy_common_name, get_id_from_legacy_common_name

--- a/tests/common_name.py
+++ b/tests/common_name.py
@@ -1,0 +1,27 @@
+import pytest
+
+from esteid.helpers import get_name_from_legacy_common_name, get_id_from_legacy_common_name
+
+
+@pytest.mark.parametrize('common_name,expected_name', [
+    ('TESTNUMBER,SEITSMES,51001091072', 'Seitsmes Testnumber'),
+    ('TESTNUMBER\\,SEITSMES\\,51001091072', 'Seitsmes Testnumber'),
+    ('TEST-NUMBER,SEITSMES MEES,51001091072', 'Seitsmes Mees Test-Number'),
+    (u'O’CONNEŽ-ŠUSLIK,MARY ÄNN,11412090004', u'Mary Änn O’Connež-Šuslik'),
+])
+def test_get_name_from_legacy_common_name(common_name, expected_name):
+    result = get_name_from_legacy_common_name(common_name)
+
+    assert result == expected_name
+
+
+@pytest.mark.parametrize('common_name,expected_id', [
+    ('TESTNUMBER,SEITSMES,51001091072', '51001091072'),
+    ('TESTNUMBER\\,SEITSMES\\,51001091072', '51001091072'),
+    ('TEST-NUMBER,SEITSMES MEES,51001091072', '51001091072'),
+    (u'O’CONNEŽ-ŠUSLIK,MARY ÄNN,11412090004', u'11412090004'),
+])
+def test_get_id_from_legacy_common_name(common_name, expected_id):
+    result = get_id_from_legacy_common_name(common_name)
+
+    assert result == expected_id

--- a/tests/distinguished_name.py
+++ b/tests/distinguished_name.py
@@ -22,8 +22,6 @@ from esteid.helpers import parse_rfc_dn, parse_legacy_dn
 def test_parse_rfc_dn(distinguished_name, expected_res):
     result = parse_rfc_dn(distinguished_name)
 
-    print('result', result)
-    print('expected', expected_res)
     assert result == expected_res
 
 

--- a/tests/distinguished_name.py
+++ b/tests/distinguished_name.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from esteid.helpers import parse_rfc_dn, parse_legacy_dn

--- a/tests/distinguished_name.py
+++ b/tests/distinguished_name.py
@@ -6,12 +6,13 @@ from esteid.helpers import parse_rfc_dn, parse_legacy_dn
 
 @pytest.mark.parametrize('distinguished_name,expected_res', [
     (
-        'serialNumber=51001091072,GN=SEITSMES,SN=TESTNUMBER,CN=TESTNUMBER\\,SEITSMES\\,51001091072,OU=authentication,O=ESTEID,C=EE',
+        u'serialNumber=51001091072,GN=SEITSMES,SN=TESTN\\C3\\9CMBER,'
+        u'CN=TESTN\\C3\\9CMBER\\,SEITSMES\\,51001091072,OU=authentication,O=ESTEID,C=EE',
         {
             'serialNumber': '51001091072',
             'GN': 'SEITSMES',
-            'SN': 'TESTNUMBER',
-            'CN': 'TESTNUMBER,SEITSMES,51001091072',
+            'SN': u'TESTNÜMBER',
+            'CN': u'TESTNÜMBER,SEITSMES,51001091072',
             'OU': 'authentication',
             'O': 'ESTEID',
             'C': 'EE',
@@ -21,17 +22,20 @@ from esteid.helpers import parse_rfc_dn, parse_legacy_dn
 def test_parse_rfc_dn(distinguished_name, expected_res):
     result = parse_rfc_dn(distinguished_name)
 
+    print('result', result)
+    print('expected', expected_res)
     assert result == expected_res
 
 
 @pytest.mark.parametrize('distinguished_name,expected_res', [
     (
-        '/serialNumber=51001091072/GN=SEITSMES/SN=TESTNUMBER/CN=TESTNUMBER,SEITSMES,51001091072/OU=authentication/O=ESTEID/C=EE',
+        u'/serialNumber=51001091072/GN=SEITSMES/SN=TESTN\\C3\\9CMBER'
+        u'/CN=TESTN\\C3\\9CMBER,SEITSMES,51001091072/OU=authentication/O=ESTEID/C=EE',
         {
             'serialNumber': '51001091072',
             'GN': 'SEITSMES',
-            'SN': 'TESTNUMBER',
-            'CN': 'TESTNUMBER,SEITSMES,51001091072',
+            'SN': u'TESTNÜMBER',
+            'CN': u'TESTNÜMBER,SEITSMES,51001091072',
             'OU': 'authentication',
             'O': 'ESTEID',
             'C': 'EE',

--- a/tests/distinguished_name.py
+++ b/tests/distinguished_name.py
@@ -1,0 +1,43 @@
+import pytest
+
+from esteid.helpers import parse_rfc_dn, parse_legacy_dn
+
+
+@pytest.mark.parametrize('distinguished_name,expected_res', [
+    (
+        'serialNumber=51001091072,GN=SEITSMES,SN=TESTNUMBER,CN=TESTNUMBER\\,SEITSMES\\,51001091072,OU=authentication,O=ESTEID,C=EE',
+        {
+            'serialNumber': '51001091072',
+            'GN': 'SEITSMES',
+            'SN': 'TESTNUMBER',
+            'CN': 'TESTNUMBER,SEITSMES,51001091072',
+            'OU': 'authentication',
+            'O': 'ESTEID',
+            'C': 'EE',
+        },
+    )
+])
+def test_parse_rfc_dn(distinguished_name, expected_res):
+    result = parse_rfc_dn(distinguished_name)
+
+    assert result == expected_res
+
+
+@pytest.mark.parametrize('distinguished_name,expected_res', [
+    (
+        '/serialNumber=51001091072/GN=SEITSMES/SN=TESTNUMBER/CN=TESTNUMBER,SEITSMES,51001091072/OU=authentication/O=ESTEID/C=EE',
+        {
+            'serialNumber': '51001091072',
+            'GN': 'SEITSMES',
+            'SN': 'TESTNUMBER',
+            'CN': 'TESTNUMBER,SEITSMES,51001091072',
+            'OU': 'authentication',
+            'O': 'ESTEID',
+            'C': 'EE',
+        },
+    )
+])
+def test_parse_legacy_dn(distinguished_name, expected_res):
+    result = parse_legacy_dn(distinguished_name)
+
+    assert result == expected_res

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,7 +15,6 @@ from mock import patch
 from esteid import config
 
 from esteid.digidocservice.containers import BdocContainer
-from esteid.digidocservice.models import Signer
 from esteid.digidocservice.service import DigiDocService, DataFile, DigiDocError
 
 
@@ -27,24 +26,6 @@ def get_digidoc_service():
     return DigiDocService(wsdl_url=config.wsdl_url(),
                           service_name='Testimine',
                           transport=Transport(cache=InMemoryCache()))
-
-
-class TestParseCommonName(TestCase):
-    def __name_test(self, common_name, id_code, expected):
-        result = Signer.parse_common_name(common_name, id_code)
-        self.assertEqual(expected, result,
-                         'parse_common_name: Expected "%s", got "%s" from common_name "%s"' % (expected,
-                                                                                               result,
-                                                                                               common_name))
-
-    def test_simple(self):
-        self.__name_test('TESTNUMBER,SEITSMES,51001091072', '51001091072', 'Seitsmes Testnumber')
-
-    def test_two_names(self):
-        self.__name_test('TEST-NUMBER,SEITSMES MEES,51001091072', '51001091072', 'Seitsmes Mees Test-Number')
-
-    def test_complex(self):
-        self.__name_test(u'O’CONNEŽ-ŠUSLIK,MARY ÄNN,11412090004', '11412090004', u'Mary Änn O’Connež-Šuslik')
 
 
 class TestMobileAuthenticate(TestCase):


### PR DESCRIPTION
- Move `Signer.parse_common_name` to helpers module

fixes #11