### PR TITLE
Add support for attrs>=19.2.0

### DIFF
--- a/esteid/digidocservice/types.py
+++ b/esteid/digidocservice/types.py
@@ -31,7 +31,7 @@ class Certificate(FromDictMixin):
     policies = attr.ib(default=attr.Factory(list), validator=[
         attr.validators.instance_of(list),
         get_typed_list_validator(CertificatePolicy),
-    ], convert=get_typed_list_converter(CertificatePolicy))
+    ], converter=get_typed_list_converter(CertificatePolicy))
 
 
 @attr.s
@@ -47,7 +47,7 @@ class Signer(FromDictMixin):
     full_name = attr.ib()
 
     certificate = attr.ib(validator=attr.validators.instance_of(Certificate),
-                          convert=get_instance_converter(Certificate))
+                          converter=get_instance_converter(Certificate))
 
     @staticmethod
     def prepare_kwargs(kwargs):
@@ -69,7 +69,7 @@ class Confirmation(FromDictMixin):
     responder_id = attr.ib()
 
     responder_certificate = attr.ib(validator=attr.validators.instance_of(ResponderCertificate),
-                                    convert=get_instance_converter(ResponderCertificate))
+                                    converter=get_instance_converter(ResponderCertificate))
 
 
 @attr.s
@@ -88,21 +88,21 @@ class SignerRole(FromDictMixin):
 
 @attr.s
 class SignatureInfo(FromDictMixin):
-    signing_time = attr.ib(validator=attr.validators.instance_of(datetime), convert=convert_time)
-    status = attr.ib(convert=convert_status)
+    signing_time = attr.ib(validator=attr.validators.instance_of(datetime), converter=convert_time)
+    status = attr.ib(converter=convert_status)
     id = attr.ib()
 
     signer = attr.ib(validator=attr.validators.instance_of(Signer),
-                     convert=get_instance_converter(Signer, prepare_kwargs=Signer.prepare_kwargs))
-    confirmation = attr.ib(validator=attr.validators.instance_of(Confirmation), convert=get_instance_converter(Confirmation))
+                     converter=get_instance_converter(Signer, prepare_kwargs=Signer.prepare_kwargs))
+    confirmation = attr.ib(validator=attr.validators.instance_of(Confirmation), converter=get_instance_converter(Confirmation))
 
     signature_production_place = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(SignatureProductionPlace)),
-                                         convert=attr.converters.optional(get_instance_converter(SignatureProductionPlace)), default=None)
+                                         converter=attr.converters.optional(get_instance_converter(SignatureProductionPlace)), default=None)
 
     signer_role = attr.ib(default=attr.Factory(list), validator=[
         attr.validators.instance_of(list),
         get_typed_list_validator(SignerRole),
-    ], convert=get_typed_list_converter(SignerRole))
+    ], converter=get_typed_list_converter(SignerRole))
 
     error = attr.ib(default=None)
     crl_info = attr.ib(default=None)
@@ -134,9 +134,9 @@ class SignedDocInfo(FromDictMixin):
     data_file_info = attr.ib(default=attr.Factory(list), validator=[
         attr.validators.instance_of(list),
         get_typed_list_validator(DataFileInfo),
-    ], convert=get_typed_list_converter(DataFileInfo))
+    ], converter=get_typed_list_converter(DataFileInfo))
 
     signature_info = attr.ib(default=attr.Factory(list), validator=[
         attr.validators.instance_of(list),
         get_typed_list_validator(SignatureInfo),
-    ], convert=get_typed_list_converter(SignatureInfo))
+    ], converter=get_typed_list_converter(SignatureInfo))

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
-pytest==4.6.5
-coverage==4.5.2
-coveralls==1.5.1
-pytest-cov==2.6.0
-pytest-django==3.4.4
+pytest>=4.6.5
+coverage==4.5.4
+coveralls==1.8.2
+pytest-cov==2.8.1
+pytest-django==3.5.1
 flake8
 mock>=1.0.1
 tox>=1.7.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==4.0.1
+pytest==4.6.5
 coverage==4.5.2
 coveralls==1.5.1
 pytest-cov==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=1.8,!=2.1.0,!=2.1.1
 attrs>=19.2.0
-lxml>=3.4
+lxml>=3.4,<=4.3.5
 zeep>=2.4.0
 pycryptodome>=3.7.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.8,!=2.1.0,!=2.1.1
-attrs>=17.2.0
+attrs>=19.2.0
 lxml>=3.4
 zeep>=2.4.0
 pycryptodome>=3.7.2

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'django>=1.8,!=2.1.0,!=2.1.1',
-        'attrs>=17.2.0',
-        'lxml>=3.4',
+        'attrs>=19.2.0',
+        'lxml>=3.4,<=4.3.5',
         'zeep>=2.4.0',
         'pycryptodome>=3.7.2',
     ],


### PR DESCRIPTION
- Rename deprecated method parameter `convert` to `converter`
- Require `pytest 4.6.5` in Tox builds