### PR TITLE
Fix issues with InvalidParameter and DataFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT := esteid
-VENV := ./venv
+VENV := ./.venv
 export PATH := $(VENV)/bin:$(PATH)
 
 .PHONY:
@@ -9,8 +9,10 @@ help:  ## Show this help.
 	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
 
 .PHONY:
-venv:  ## Create virtualenv in ./venv or $(VENV)
-	python -m venv venv
+venv: .venv  ## Create virtualenv in $(VENV)
+
+.venv:  ## Create virtualenv in ./venv or $(VENV)
+	python -m venv --prompt=django-esteid $(VENV)
 	pip install -r requirements-dev.txt
 
 .PHONY:

--- a/esteid/__init__.py
+++ b/esteid/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "3.0b0"
+__version__ = "3.0b2"

--- a/esteid/exceptions.py
+++ b/esteid/exceptions.py
@@ -135,18 +135,25 @@ class InvalidParameters(EsteidError):
 
 
 class InvalidParameter(InvalidParameters):
-    """Invalid initialization parameters received from the request.
+    """Invalid initialization parameter PARAM received from the request.
 
     Takes a `param` kwarg
     """
 
     default_message = _("Invalid value for parameter {param}.")
 
+    def __init__(self, message=None, *, param, **kwargs):
+        super().__init__(message)
+        self.kwargs = {**kwargs, "param": param}
+
 
 class InvalidIdCode(InvalidParameter):
     """Invalid ID code (format or checksum don't match)"""
 
     default_message = _("Invalid ID code.")
+
+    def __init__(self, message=None, *, param="id_code", **kwargs):
+        super().__init__(message, param=param, **kwargs)
 
 
 class UserNotRegistered(EsteidError):

--- a/esteid/mobileid/tests/test_mobileidsigner.py
+++ b/esteid/mobileid/tests/test_mobileidsigner.py
@@ -8,7 +8,7 @@ import pytest
 from esteid.mobileid import MobileIdSigner
 from esteid.mobileid import signer as signer_module
 
-from ...exceptions import InvalidIdCode, InvalidParameter, SigningSessionDoesNotExist
+from ...exceptions import InvalidIdCode, InvalidParameter, InvalidParameters, SigningSessionDoesNotExist
 
 
 @pytest.fixture()
@@ -43,12 +43,12 @@ def mobileidservice():
     [
         pytest.param(
             None,
-            InvalidParameter,
+            InvalidParameters,
             id="No data",
         ),
         pytest.param(
             {},
-            InvalidParameter,
+            InvalidParameters,
             id="Empty data",
         ),
         pytest.param(

--- a/esteid/signing/README.md
+++ b/esteid/signing/README.md
@@ -20,10 +20,6 @@ from django.views.generic import DetailView
 from esteid.compat import container_info
 from esteid.signing import Container, DataFile, SignViewDjangoMixin
 
-# Import all the necessary signers (a.k.a registration)
-from esteid.idcard import IdCardSigner  # noqa
-from esteid.mobileid import MobileIdSigner  # noqa
-
 class MyDocumentSignView(SignViewDjangoMixin, DetailView):
     def get_files_to_sign(self, *args, **kwargs):
         instance = self.get_object()
@@ -44,7 +40,18 @@ class MyDocumentSignView(SignViewDjangoMixin, DetailView):
 from django.urls.conf import re_path
 
 from esteid.signing import Signer
+# Import all the necessary signers (a.k.a registration)
+from esteid.idcard import IdCardSigner
+from esteid.mobileid import MobileIdSigner
+from esteid.smartid import SmartIdSigner
 from .views import MyDocumentSignView
+
+
+assert Signer.SIGNING_METHODS == {
+    'idcard': IdCardSigner,
+    'mobileid': MobileIdSigner,
+    'smartid': SmartIdSigner,
+}
 
 urlpatterns = [
     re_path(rf"^/document/(?P<id>\w+)/sign/{method}/", 
@@ -118,8 +125,8 @@ Also if container is stored in a remote storage, updating it in place can be imp
 ### File types
 
 To generate a signature over files, it is necessary to know the file name, its mime type, and the content.
-To simplify providing these data to `get_files_to_sign()`, a wrapper class `DataFile` is included which
-accepts a path to file, or a django File instance, and a `mime_type` argument, and deals with reading the file content
+To simplify providing these data to `get_files_to_sign()`, a wrapper class [`DataFile`](./types.py) is included which
+accepts a path to file, or a django `File` instance, and a `mime_type` argument, and deals with reading the file content
 when appropriate.
 
 ## Implementation details

--- a/esteid/signing/tests/test_types.py
+++ b/esteid/signing/tests/test_types.py
@@ -1,8 +1,25 @@
 import base64
+import pathlib
 
 import pytest
 
-from ..types import InterimSessionData
+from django.core.files import File
+
+from ..types import DataFile, InterimSessionData
+
+
+TEST_TXT = "test.txt"
+TEST_TXT_CONTENT = b"Hello"
+
+
+@pytest.fixture()
+def test_txt(tmp_path):
+    # Can't pass fixtures to parametrize() so we need a well-known file name for a parameterized test.
+    # tmp_path is pytest's builtin fixture with a temporary path as a pathlib.Path object
+    with open(tmp_path / TEST_TXT, "wb") as f:
+        f.write(TEST_TXT_CONTENT)
+
+    yield open(tmp_path / TEST_TXT, "rb")
 
 
 @pytest.mark.parametrize(
@@ -40,3 +57,85 @@ def test_signing_types_session_data(value, result):
         assert data.digest == base64.b64decode(value["digest_b64"])
         assert data.temp_container_file == value["temp_container_file"]
         assert data.temp_signature_file == value["temp_signature_file"]
+
+
+@pytest.mark.parametrize(
+    "params,result",
+    [
+        pytest.param(
+            {},
+            TypeError("required positional argument.+wraps"),
+            id="empty params",
+        ),
+        pytest.param(
+            {"wraps": ..., "file_name": TEST_TXT},
+            TypeError("Expected a Django File or path to file"),
+            id="wraps not a string",
+        ),
+        pytest.param(
+            {"wraps": TEST_TXT},
+            TEST_TXT_CONTENT,
+            id="wraps a string",
+        ),
+        pytest.param(
+            {"wraps": TEST_TXT, "file_name": "other.name"},
+            TEST_TXT_CONTENT,
+            id="wraps a string, gets file_name",
+        ),
+        pytest.param(
+            {"wraps": TEST_TXT, "file_name": "other.name", "content": b"test", "mime_type": "text/plain"},
+            b"test",
+            id="wraps a string, all arguments",
+        ),
+        pytest.param(
+            {"wraps": pathlib.PurePath(TEST_TXT)},
+            TEST_TXT_CONTENT,
+            id="wraps a PurePath",
+        ),
+        pytest.param(
+            {"wraps": pathlib.PosixPath(TEST_TXT), "file_name": "other.name"},
+            TEST_TXT_CONTENT,
+            id="wraps a PosixPath",
+        ),
+        pytest.param(
+            {"wraps": pathlib.Path(TEST_TXT), "file_name": "other.name", "content": b"test", "mime_type": "text/plain"},
+            b"test",
+            id="wraps a Path, all arguments",
+        ),
+        pytest.param(
+            {"wraps": File},
+            TEST_TXT_CONTENT,
+            id="wraps a File",
+        ),
+        pytest.param(
+            {"wraps": File, "file_name": "other.name"},
+            TEST_TXT_CONTENT,
+            id="wraps a File, alternative file name",
+        ),
+        pytest.param(
+            {"wraps": File, "file_name": "other.name", "content": b"test", "mime_type": "text/plain"},
+            b"test",
+            id="wraps a File, all arguments",
+        ),
+    ],
+)
+def test_signing_types_data_file(params: dict, result, tmp_path, test_txt):
+    if isinstance(result, Exception):
+        with pytest.raises(type(result), match=result.args[0]):
+            DataFile(**params)
+
+    else:
+        # some preparations
+        if params["wraps"] is File:
+            params["wraps"] = File(test_txt)
+        else:
+            params["wraps"] = str(tmp_path / TEST_TXT)
+
+        datafile = DataFile(**params)
+        assert datafile.wrapped_file == params["wraps"]
+        assert datafile.content == params.get("content")
+        assert datafile.file_name == (params.get("file_name") or TEST_TXT)
+        assert datafile.mime_type == params.get("mime_type", "application/octet-stream")
+
+        data = datafile.read()
+        assert data == result

--- a/esteid/smartid/signer.py
+++ b/esteid/smartid/signer.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import pyasice
 from pyasice import Container, XmlSignature
 
-from esteid.exceptions import ActionInProgress, InvalidIdCode, InvalidParameter
+from esteid.exceptions import ActionInProgress, InvalidIdCode, InvalidParameters
 from esteid.signing import DataFile, Signer
 from esteid.signing.types import InterimSessionData, PredictableDict
 
@@ -50,7 +50,7 @@ class SmartIdSigner(Signer):
         Receives user input via POST: `id_code`, `country`
         """
         if not isinstance(initial_data, dict):
-            raise InvalidParameter("Missing required parameters")
+            raise InvalidParameters("Missing required parameters")
 
         user_input = UserInput(**initial_data)
 
@@ -60,7 +60,7 @@ class SmartIdSigner(Signer):
             # Just to be explicit
             raise
         except ValueError as e:
-            raise InvalidParameter("Invalid parameters") from e
+            raise InvalidParameters from e
 
         self.id_code = user_input.id_code
         self.country = user_input.country


### PR DESCRIPTION
* An exception of type `InvalidParameter` requires a keyword argument.
  Made it explicit and fixed places where it was not used,
  replacing some with a more generic `InvalidParameters` error.
* In Django 1.11, the `File.open()` method returns None and thus can't be used as context manager.
  Also added support for `pathlib.*Path` file paths and extensive testing.
* Changed default venv path in Makefile to `.venv`
  (some command line search tools ignore dot-dirs by default) and added prompt.