### PR TITLE
SmartID Signing Action: remove auth step

### DIFF
--- a/esteid/templates/esteid/test.html
+++ b/esteid/templates/esteid/test.html
@@ -186,7 +186,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="smartid-step">Verification code</h4>
+                <h4 class="modal-title">Verification code</h4>
             </div>
 
             <div class="modal-body">
@@ -344,32 +344,15 @@
 
             var timeoutForVerificationCode = 2000  // delay polling to let user to enter verification code
 
-            function onSuccessAuth(response) {
-                // Got a successful auth-start request...
-                console.log('SmartID: auth verification code', response.verification_code)
+            function onStartSign(response) {
+                // Got a successful sign-start request...
+                console.log('SmartID: Signing verification code', response.verification_code)
+
                 $('#verification-code-modal').modal({
                     backdrop: 'static',
                     keyboard: false
                 })
 
-                $('#smartid-step').text('Authentication')
-                $('#smartid-verification-code').text(response.verification_code)
-
-                // ...next phase: start signing
-                // we don't want to start polling immediately because user will need to enter verification code
-                setTimeout(function () {
-                    manager.smartidStatus({csrfmiddlewaretoken: csrf_token}).then(
-                        onStartSign,
-                        onError
-                    )
-                }, timeoutForVerificationCode)
-            }
-
-            function onStartSign(response) {
-                // Got a successful sign-start request...
-                console.log('SmartID: Auth OK, Signing verification code', response.verification_code)
-
-                $('#smartid-step').text('Signing')
                 $('#smartid-verification-code').text(response.verification_code)
 
                 // ...next phase: poll for status of signing
@@ -402,7 +385,7 @@
                 csrfmiddlewaretoken: csrf_token
             }).then(
                 // Start callback hell
-                onSuccessAuth,
+                onStartSign,
                 onError
             )
         }

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,4 +1,4 @@
 attrs>=19.2.0
 esteid-certificates==1.0.*
-pyasice==1.0.*
+pyasice==1.0.*,>=1.0.1
 requests>=2.20


### PR DESCRIPTION
As it turned out, the authentication step before signing is no longer necessary and signing can be started by a call to `select_signing_certificate`.

Since authentication is a paid transaction, it makes sense to remove this step.

Also updated `pyasice` to 1.0.1 , see https://github.com/thorgate/pyasice/pull/4