### PR TITLE
Use a single point of configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,32 +16,16 @@ jobs:
 
     - python: 3.6
       env:
-        - DJANGO=2.1
-
-    - python: 3.6
-      env:
         - DJANGO=3.0
-
-    - python: 3.7
-      env:
-        - DJANGO=2.0
 
     - python: 3.7
       env:
         - DJANGO=2.1
       after_success: coveralls
 
-    - python: 3.7
-      env:
-        - DJANGO=3.0
-
     - python: 3.8
       env:
         - DJANGO=2.0
-
-    - python: 3.8
-      env:
-        - DJANGO=2.1
 
     - python: 3.8
       # ensure bionic also passes checks

--- a/esteid/constants.py
+++ b/esteid/constants.py
@@ -1,8 +1,14 @@
 MOBILE_ID_DEMO_URL = "https://tsp.demo.sk.ee/mid-api"
 MOBILE_ID_LIVE_URL = "https://mid.sk.ee/mid-api"
 
+MOBILE_ID_DEMO_SERVICE_NAME = "DEMO"
+MOBILE_ID_DEMO_SERVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 SMART_ID_DEMO_URL = "https://sid.demo.sk.ee/smart-id-rp/v1"
 SMART_ID_LIVE_URL = "https://rp-api.smart-id.com/v1"
+
+SMART_ID_DEMO_SERVICE_NAME = MOBILE_ID_DEMO_SERVICE_NAME
+SMART_ID_DEMO_SERVICE_UUID = MOBILE_ID_DEMO_SERVICE_UUID
 
 OCSP_DEMO_URL = "http://demo.sk.ee/ocsp"
 OCSP_LIVE_URL = "http://ocsp.sk.ee/"
@@ -21,3 +27,11 @@ HASH_ALGORITHMS = {
     HASH_SHA384,
     HASH_SHA512,
 }
+
+
+class Countries:
+    ESTONIA = "EE"
+    LATVIA = "LV"
+    LITHUANIA = "LT"
+
+    ALL = (ESTONIA, LATVIA, LITHUANIA)

--- a/esteid/context_processors.py
+++ b/esteid/context_processors.py
@@ -1,12 +1,12 @@
-from django.conf import settings
+from esteid import settings
 
 
 def esteid_services(*_, **__):
     return {
-        "ESTEID_DEMO": getattr(settings, "ESTEID_DEMO", True),
-        "ID_CARD_ENABLED": getattr(settings, "ID_CARD_ENABLED", False),
-        "MOBILE_ID_ENABLED": getattr(settings, "MOBILE_ID_ENABLED", False),
-        "MOBILE_ID_TEST_MODE": getattr(settings, "MOBILE_ID_TEST_MODE", True),
-        "SMART_ID_ENABLED": getattr(settings, "SMART_ID_ENABLED", False),
-        "SMART_ID_TEST_MODE": getattr(settings, "SMART_ID_TEST_MODE", True),
+        "ESTEID_DEMO": settings.ESTEID_DEMO,
+        "ID_CARD_ENABLED": settings.ID_CARD_ENABLED,
+        "MOBILE_ID_ENABLED": settings.MOBILE_ID_ENABLED,
+        "MOBILE_ID_TEST_MODE": settings.MOBILE_ID_TEST_MODE,
+        "SMART_ID_ENABLED": settings.SMART_ID_ENABLED,
+        "SMART_ID_TEST_MODE": settings.SMART_ID_TEST_MODE,
     }

--- a/esteid/middleware.py
+++ b/esteid/middleware.py
@@ -1,12 +1,11 @@
 import logging
 import warnings
 
-from django.conf import settings
 from esteid_certificates import get_certificate_file_name
 
+from esteid import settings
 from esteid.util import parse_legacy_dn, parse_rfc_dn
 
-from . import constants
 from .ocsp import OCSPVerifier
 
 
@@ -22,10 +21,6 @@ logger = logging.getLogger(__name__)
 
 ERROR_NO_DN = 3000
 ERROR_INVALID_DN = 3001
-
-ESTEID_DEMO = getattr(settings, "ESTEID_DEMO", True)
-
-OCSP_URL = getattr(settings, "ESTEID_OCSP_URL", constants.OCSP_DEMO_URL if ESTEID_DEMO else constants.OCSP_LIVE_URL)
 
 
 class BaseIdCardMiddleware(MiddlewareMixin):
@@ -117,7 +112,7 @@ class BaseIdCardMiddleware(MiddlewareMixin):
 
         :return:str
         """
-        return OCSP_URL
+        return settings.OCSP_URL
 
     @classmethod
     def get_ocsp_responder_certificate_path(cls):
@@ -136,7 +131,7 @@ class BaseIdCardMiddleware(MiddlewareMixin):
         if certificate_path == "sk-ocsp-responder-certificates.pem":
             return get_certificate_file_name(live_cert_name)
 
-        return test_cert_name if ESTEID_DEMO else live_cert_name
+        return test_cert_name if settings.ESTEID_DEMO else live_cert_name
 
     @classmethod
     def verify_ocsp(cls, certificate, issuer):

--- a/esteid/mobileid/i18n.py
+++ b/esteid/mobileid/i18n.py
@@ -1,8 +1,7 @@
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
-from esteid.constants import MOBILE_ID_DEMO_URL, MOBILE_ID_LIVE_URL
+from esteid import settings
 
 from .base import MobileIDService
 
@@ -18,23 +17,13 @@ class TranslatedMobileIDService(MobileIDService):
     def get_instance(cls) -> "TranslatedMobileIDService":
         cls.configuration_valid()
 
-        # NOTE: Test mode ON by default. To prevent accidental billing
-        test_mode = getattr(settings, "MOBILE_ID_TEST_MODE", True)
-        api_root = getattr(settings, "MOBILE_ID_API_ROOT", MOBILE_ID_DEMO_URL if test_mode else MOBILE_ID_LIVE_URL)
-
         return cls(
             rp_uuid=settings.MOBILE_ID_SERVICE_UUID,
             rp_name=settings.MOBILE_ID_SERVICE_NAME,
-            api_root=api_root,
+            api_root=settings.MOBILE_ID_API_ROOT,
         )
 
     @staticmethod
     def configuration_valid():
-        """Check if the required Mobile-ID configuration parameters are set"""
-        keys = [
-            "MOBILE_ID_SERVICE_NAME",
-            "MOBILE_ID_SERVICE_UUID",
-        ]
-
-        if not all(getattr(settings, k, False) for k in keys):
-            raise ImproperlyConfigured("One of the following settings is missing: {}".format(",".join(keys)))
+        if not (settings.MOBILE_ID_SERVICE_NAME and settings.MOBILE_ID_SERVICE_UUID):
+            raise ImproperlyConfigured("Both MOBILE_ID_SERVICE_NAME and MOBILE_ID_SERVICE_UUID must be set")

--- a/esteid/mobileid/signer.py
+++ b/esteid/mobileid/signer.py
@@ -2,15 +2,12 @@ import logging
 import re
 from typing import List, Optional
 
-from django.conf import settings
-
 from pyasice import Container, XmlSignature
 
 from esteid.exceptions import ActionInProgress, InvalidIdCode, InvalidParameter, InvalidParameters
 from esteid.signing import DataFile, Signer
 from esteid.signing.types import InterimSessionData, PredictableDict
 
-from .. import constants
 from ..util import id_code_ee_is_valid
 from .constants import Languages
 from .i18n import TranslatedMobileIDService
@@ -18,14 +15,8 @@ from .i18n import TranslatedMobileIDService
 
 logger = logging.getLogger(__name__)
 
-ESTEID_DEMO = getattr(settings, "ESTEID_DEMO", True)
-ESTEID_USE_LT_TS = getattr(settings, "ESTEID_USE_LT_TS", True)
 
-OCSP_URL = getattr(settings, "ESTEID_OCSP_URL", constants.OCSP_DEMO_URL if ESTEID_DEMO else constants.OCSP_LIVE_URL)
-TSA_URL = getattr(settings, "ESTEID_TSA_URL", constants.TSA_DEMO_URL if ESTEID_DEMO else constants.TSA_LIVE_URL)
-
-
-PHONE_NUMBER_REGEXP = r"^\+37[02]\d{7,8}$"  # Mobile ID supports Estonian and Lithuanian phones
+PHONE_NUMBER_REGEXP = re.compile(r"^\+37[02]\d{7,8}$")  # Mobile ID supports Estonian and Lithuanian phones
 
 
 class UserInput(PredictableDict):

--- a/esteid/mobileid/tests/conftest.py
+++ b/esteid/mobileid/tests/conftest.py
@@ -1,10 +1,9 @@
 import base64
 import hashlib
-import uuid
 
 import pytest
 
-from esteid.constants import HASH_SHA512, MOBILE_ID_DEMO_URL
+from esteid.constants import HASH_SHA512, MOBILE_ID_DEMO_SERVICE_NAME, MOBILE_ID_DEMO_SERVICE_UUID, MOBILE_ID_DEMO_URL
 from esteid.tests.conftest import *  # noqa: F401, F403 -- Force pytest to load fixtures from the common conftest
 
 from ..base import MobileIDService
@@ -16,12 +15,12 @@ from ..utils import get_verification_code
 
 @pytest.fixture()
 def demo_mid_api():
-    return MobileIDService(uuid.UUID("00000000-0000-0000-0000-000000000000"), "DEMO", MOBILE_ID_DEMO_URL)
+    return MobileIDService(MOBILE_ID_DEMO_SERVICE_UUID, MOBILE_ID_DEMO_SERVICE_NAME, MOBILE_ID_DEMO_URL)
 
 
 @pytest.fixture()
 def i18n_demo_mid_api():
-    return TranslatedMobileIDService(uuid.UUID("00000000-0000-0000-0000-000000000000"), "DEMO", MOBILE_ID_DEMO_URL)
+    return TranslatedMobileIDService(MOBILE_ID_DEMO_SERVICE_UUID, MOBILE_ID_DEMO_SERVICE_NAME, MOBILE_ID_DEMO_URL)
 
 
 @pytest.fixture()

--- a/esteid/mobileid/tests/test_base.py
+++ b/esteid/mobileid/tests/test_base.py
@@ -1,0 +1,90 @@
+import pytest
+
+import requests_mock
+from django.core.exceptions import ImproperlyConfigured
+from requests.exceptions import ConnectTimeout
+
+from esteid.tests.conftest import override_esteid_settings
+
+from ...constants import MOBILE_ID_DEMO_URL, MOBILE_ID_LIVE_URL
+from ...exceptions import EsteidError, InvalidCredentials, OfflineError, UpstreamServiceError
+from .. import MobileIDError
+from ..base import MobileIDService
+from ..i18n import TranslatedMobileIDService
+
+
+def test_error():
+    assert MobileIDError is EsteidError
+
+
+@pytest.mark.parametrize("exc", [ConnectionError, ConnectTimeout])
+def test_mobileid_invoke_timeout(demo_mid_api, exc):
+    with requests_mock.mock() as m:
+        m.get(demo_mid_api.api_url(""), exc=exc)
+
+        with pytest.raises(OfflineError) as exc_info:
+            demo_mid_api.invoke("")
+
+        assert demo_mid_api.NAME in exc_info.value.get_message()
+
+
+@pytest.mark.parametrize(
+    "status_code,exc",
+    [
+        (401, InvalidCredentials),
+        (580, OfflineError),
+        (502, OfflineError),
+        (503, OfflineError),
+        (504, OfflineError),
+        (400, MobileIDError),
+        (500, UpstreamServiceError),
+    ],
+)
+def test_mobileid_invoke_errors(demo_mid_api, status_code, exc):
+    with requests_mock.mock() as m:
+        m.get(demo_mid_api.api_url(""), status_code=status_code)
+
+        with pytest.raises(exc):
+            demo_mid_api.invoke("")
+
+
+def test_mobileid_service(demo_mid_api):
+    assert demo_mid_api.api_root == MOBILE_ID_DEMO_URL
+
+    service = MobileIDService("00000000-0000-0000-0000-000000000000", "test", MOBILE_ID_LIVE_URL)
+    assert service.api_root == MOBILE_ID_LIVE_URL
+    assert service.rp_uuid == "00000000-0000-0000-0000-000000000000"
+    assert service.rp_name == "test"
+
+
+def test_mobileid_translated_service(i18n_demo_mid_api):
+    assert i18n_demo_mid_api.api_root == MOBILE_ID_DEMO_URL
+
+
+def test_mobileid_translated_service_test_mode_off(i18n_demo_mid_api):
+    with override_esteid_settings(
+        MOBILE_ID_TEST_MODE=False,
+        MOBILE_ID_SERVICE_UUID="00000000-0000-0000-0000-000000000000",
+        MOBILE_ID_SERVICE_NAME="test",
+    ):
+        service = TranslatedMobileIDService.get_instance()
+        assert service.api_root == MOBILE_ID_LIVE_URL
+        assert service.rp_uuid == "00000000-0000-0000-0000-000000000000"
+        assert service.rp_name == "test"
+
+
+def test_mobileid_translated_service_requires_creds_for_live():
+    with override_esteid_settings(MOBILE_ID_TEST_MODE=False):
+        with pytest.raises(ImproperlyConfigured, match="MOBILE_ID_SERVICE_NAME and MOBILE_ID_SERVICE_UUID"):
+            TranslatedMobileIDService.get_instance()
+
+    with override_esteid_settings(
+        MOBILE_ID_TEST_MODE=False,
+        MOBILE_ID_SERVICE_UUID="00000000-0000-0000-0000-000000000000",
+    ):
+        with pytest.raises(ImproperlyConfigured, match="MOBILE_ID_SERVICE_NAME and MOBILE_ID_SERVICE_UUID"):
+            TranslatedMobileIDService.get_instance()
+
+    with override_esteid_settings(MOBILE_ID_TEST_MODE=False, MOBILE_ID_SERVICE_NAME="name"):
+        with pytest.raises(ImproperlyConfigured, match="MOBILE_ID_SERVICE_NAME and MOBILE_ID_SERVICE_UUID"):
+            TranslatedMobileIDService.get_instance()

--- a/esteid/settings.py
+++ b/esteid/settings.py
@@ -1,0 +1,63 @@
+"""
+This module contains all configuration settings for django-esteid.
+"""
+from django.conf import settings
+
+from esteid import constants
+from esteid.constants import Countries
+
+
+# Whether to use demo OCSP and TSA services.
+ESTEID_DEMO = getattr(settings, "ESTEID_DEMO", True)
+
+# Whether to use the ID card signing method
+ID_CARD_ENABLED = getattr(settings, "ID_CARD_ENABLED", False)
+
+# *** Mobile ID ***
+
+MOBILE_ID_ENABLED = getattr(settings, "MOBILE_ID_ENABLED", False)
+# Whether to use demo services and credentials for Mobile ID
+# NOTE: Test mode ON by default. To prevent accidental billing
+MOBILE_ID_TEST_MODE = getattr(settings, "MOBILE_ID_TEST_MODE", True)
+# MobileID Relying party name and UUID, for DEMO they are always the same so no need to explicitly set them
+MOBILE_ID_SERVICE_NAME = getattr(
+    settings, "MOBILE_ID_SERVICE_NAME", None if not MOBILE_ID_TEST_MODE else constants.MOBILE_ID_DEMO_SERVICE_NAME
+)
+MOBILE_ID_SERVICE_UUID = getattr(
+    settings, "MOBILE_ID_SERVICE_UUID", None if not MOBILE_ID_TEST_MODE else constants.MOBILE_ID_DEMO_SERVICE_UUID
+)
+MOBILE_ID_API_ROOT = getattr(
+    settings,
+    "MOBILE_ID_API_ROOT",
+    constants.MOBILE_ID_DEMO_URL if MOBILE_ID_TEST_MODE else constants.MOBILE_ID_LIVE_URL,
+)
+
+# *** Smart ID ***
+
+SMART_ID_ENABLED = getattr(settings, "SMART_ID_ENABLED", False)
+# Whether to use demo services and credentials for Smart ID
+# NOTE: Test mode ON by default. To prevent accidental billing
+SMART_ID_TEST_MODE = getattr(settings, "SMART_ID_TEST_MODE", True)
+# SmartID Relying party name and UUID, for DEMO they are always the same so no need to explicitly set them
+SMART_ID_SERVICE_NAME = getattr(
+    settings, "SMART_ID_SERVICE_NAME", None if not SMART_ID_TEST_MODE else constants.SMART_ID_DEMO_SERVICE_NAME
+)
+SMART_ID_SERVICE_UUID = getattr(
+    settings, "SMART_ID_SERVICE_UUID", None if not SMART_ID_TEST_MODE else constants.SMART_ID_DEMO_SERVICE_UUID
+)
+SMART_ID_API_ROOT = getattr(
+    settings, "SMART_ID_API_ROOT", constants.SMART_ID_DEMO_URL if SMART_ID_TEST_MODE else constants.SMART_ID_LIVE_URL
+)
+
+# The default country (mostly for SmartID)
+ESTEID_COUNTRY = getattr(settings, "ESTEID_COUNTRY", Countries.ESTONIA)
+
+# Whether to generate an LT-TS profile ASiC-E container (involves a TimeStamping confirmation)
+ESTEID_USE_LT_TS = getattr(settings, "ESTEID_USE_LT_TS", True)
+
+# URLs for OCSP and TSA services
+OCSP_URL = getattr(settings, "ESTEID_OCSP_URL", constants.OCSP_DEMO_URL if ESTEID_DEMO else constants.OCSP_LIVE_URL)
+TSA_URL = getattr(settings, "ESTEID_TSA_URL", constants.TSA_DEMO_URL if ESTEID_DEMO else constants.TSA_LIVE_URL)
+
+# Used exclusively by esteid.middleware.BaseIdCardMiddleware
+ESTEID_OCSP_RESPONDER_CERTIFICATE_PATH = getattr(settings, "ESTEID_OCSP_RESPONDER_CERTIFICATE_PATH", None)

--- a/esteid/signing/signer.py
+++ b/esteid/signing/signer.py
@@ -4,23 +4,16 @@ from tempfile import NamedTemporaryFile
 from time import time
 from typing import BinaryIO, Dict, List, Type, Union
 
-from django.conf import settings
 from esteid_certificates import get_certificate
 
 import pyasice
 from pyasice import Container, XmlSignature
 
+from esteid import settings
 from esteid.exceptions import EsteidError, SigningSessionDoesNotExist, SigningSessionExists, UpstreamServiceError
 
-from .. import constants
 from .types import DataFile, InterimSessionData
 
-
-ESTEID_DEMO = getattr(settings, "ESTEID_DEMO", True)
-ESTEID_USE_LT_TS = getattr(settings, "ESTEID_USE_LT_TS", True)
-
-OCSP_URL = getattr(settings, "ESTEID_OCSP_URL", constants.OCSP_DEMO_URL if ESTEID_DEMO else constants.OCSP_LIVE_URL)
-TSA_URL = getattr(settings, "ESTEID_TSA_URL", constants.TSA_DEMO_URL if ESTEID_DEMO else constants.TSA_LIVE_URL)
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +219,13 @@ class Signer:
         issuer_cert = get_certificate(xml_sig.get_certificate_issuer_common_name())
 
         try:
-            pyasice.finalize_signature(xml_sig, issuer_cert, lt_ts=ESTEID_USE_LT_TS, ocsp_url=OCSP_URL, tsa_url=TSA_URL)
+            pyasice.finalize_signature(
+                xml_sig,
+                issuer_cert,
+                lt_ts=settings.ESTEID_USE_LT_TS,
+                ocsp_url=settings.OCSP_URL,
+                tsa_url=settings.TSA_URL,
+            )
         except pyasice.Error as e:
             logger.exception("Signature confirmation service error")
             raise UpstreamServiceError("Signature confirmation service error") from e

--- a/esteid/smartid/constants.py
+++ b/esteid/smartid/constants.py
@@ -1,9 +1,4 @@
-class Countries:
-    ESTONIA = "EE"
-    LATVIA = "LV"
-    LITHUANIA = "LT"
-
-    ALL = (ESTONIA, LATVIA, LITHUANIA)
+from esteid.constants import Countries  # noqa
 
 
 CERTIFICATE_LEVEL_QUALIFIED = "QUALIFIED"

--- a/esteid/smartid/i18n.py
+++ b/esteid/smartid/i18n.py
@@ -1,8 +1,8 @@
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
-from ..constants import SMART_ID_DEMO_URL, SMART_ID_LIVE_URL
+from esteid import settings
+
 from .base import SmartIDService
 
 
@@ -16,27 +16,13 @@ class TranslatedSmartIDService(SmartIDService):
     def get_instance(cls):
         cls.configuration_valid()
 
-        # NOTE: Test mode ON by default. To prevent accidental billing
-        test_mode = getattr(settings, "SMART_ID_TEST_MODE", True)
-        api_root = getattr(
-            settings,
-            "SMART_ID_API_ROOT",
-            SMART_ID_DEMO_URL if test_mode else SMART_ID_LIVE_URL,
-        )
-
         return TranslatedSmartIDService(
             rp_uuid=settings.SMART_ID_SERVICE_UUID,
             rp_name=settings.SMART_ID_SERVICE_NAME,
-            api_root=api_root,
+            api_root=settings.SMART_ID_API_ROOT,
         )
 
     @staticmethod
     def configuration_valid():
-        """Check if the required Smart-ID configuration parameters are set"""
-        keys = [
-            "SMART_ID_SERVICE_NAME",
-            "SMART_ID_SERVICE_UUID",
-        ]
-
-        if not all(getattr(settings, k, False) for k in keys):
-            raise ImproperlyConfigured("One of the following settings is missing: {}".format(",".join(keys)))
+        if not (settings.SMART_ID_SERVICE_NAME and settings.SMART_ID_SERVICE_UUID):
+            raise ImproperlyConfigured("Both SMART_ID_SERVICE_NAME and SMART_ID_SERVICE_UUID must be set")

--- a/esteid/smartid/tests/conftest.py
+++ b/esteid/smartid/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from esteid.tests.conftest import *  # noqa: F401, F403  -- force pytest to use fixtures from that file
 
-from ...constants import HASH_SHA512, SMART_ID_DEMO_URL
+from ...constants import HASH_SHA512, SMART_ID_DEMO_SERVICE_NAME, SMART_ID_DEMO_SERVICE_UUID, SMART_ID_DEMO_URL
 from ...util import generate_hash
 from ..base import SmartIDService
 from ..constants import CERTIFICATE_LEVEL_QUALIFIED, EndResults
@@ -15,12 +15,12 @@ from ..utils import get_verification_code
 
 @pytest.fixture
 def demo_api():
-    return SmartIDService("00000000-0000-0000-0000-000000000000", "DEMO", SMART_ID_DEMO_URL)
+    return SmartIDService(SMART_ID_DEMO_SERVICE_UUID, SMART_ID_DEMO_SERVICE_NAME, SMART_ID_DEMO_URL)
 
 
 @pytest.fixture
 def i18n_demo_api():
-    return TranslatedSmartIDService("00000000-0000-0000-0000-000000000000", "DEMO", SMART_ID_DEMO_URL)
+    return TranslatedSmartIDService(SMART_ID_DEMO_SERVICE_UUID, SMART_ID_DEMO_SERVICE_NAME, SMART_ID_DEMO_URL)
 
 
 @pytest.fixture

--- a/esteid/tests/conftest.py
+++ b/esteid/tests/conftest.py
@@ -1,7 +1,13 @@
 import base64
+import importlib
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+
+from django.test import override_settings
+
+import esteid.settings
 
 
 @pytest.fixture
@@ -138,3 +144,12 @@ def signed_container_file():
     """A real container signed via the Demo MobileID service with a test account"""
     with open(Path(__file__).parent / "files" / "signed-test-mobileid-ee.asice", "rb") as f:
         yield f
+
+
+@contextmanager
+def override_esteid_settings(**kwargs):
+    with override_settings(**kwargs):
+        importlib.reload(esteid.settings)
+        yield
+
+    importlib.reload(esteid.settings)

--- a/esteid/tests/test_base_service.py
+++ b/esteid/tests/test_base_service.py
@@ -1,0 +1,15 @@
+import uuid
+
+import pytest
+
+from esteid.base_service import BaseSKService
+from esteid.exceptions import EsteidError
+
+
+def test_base_service_accepts_parameters():
+    rp_uuid = uuid.uuid4()
+    assert BaseSKService(rp_uuid, "name", "url").rp_uuid == str(rp_uuid)
+    assert BaseSKService(str(rp_uuid), "name", "url").rp_uuid == str(rp_uuid)
+
+    with pytest.raises(EsteidError, match="valid UUID"):
+        BaseSKService("not uuid", "name", "url")

--- a/esteid/tests/test_context_processors.py
+++ b/esteid/tests/test_context_processors.py
@@ -1,14 +1,8 @@
-from unittest.mock import patch
-
-from django.test import override_settings
-
 from esteid import context_processors
+from esteid.tests.conftest import override_esteid_settings
 
 
 def test_context_processors_esteid_services():
-    with patch.object(context_processors, "settings", None):
-        assert context_processors.esteid_services()["ESTEID_DEMO"]
-
     test_settings = {
         "ESTEID_DEMO": 1,
         "ID_CARD_ENABLED": 2,
@@ -17,5 +11,8 @@ def test_context_processors_esteid_services():
         "SMART_ID_ENABLED": 5,
         "SMART_ID_TEST_MODE": 6,
     }
-    with override_settings(**test_settings):
+
+    assert tuple(context_processors.esteid_services().keys()) == tuple(test_settings.keys())
+
+    with override_esteid_settings(**test_settings):
         assert context_processors.esteid_services() == test_settings

--- a/esteid/tests/test_settings.py
+++ b/esteid/tests/test_settings.py
@@ -1,0 +1,11 @@
+import importlib
+
+from django.test import override_settings
+
+import esteid.settings
+
+
+def test_importlib():
+    with override_settings(MOBILE_ID_TEST_MODE=False):
+        importlib.reload(esteid.settings)
+        assert esteid.settings.MOBILE_ID_TEST_MODE is False

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,19 +1,12 @@
 import os
 
 # ****** Esteid service settings ******
+# Refer to esteid.settings for a comprehensive list of settings.
 
 ESTEID_DEMO = True
 ID_CARD_ENABLED = True
-
 MOBILE_ID_ENABLED = True
-MOBILE_ID_SERVICE_NAME = 'DEMO'
-MOBILE_ID_SERVICE_UUID = '00000000-0000-0000-0000-000000000000'
-MOBILE_ID_TEST_MODE = True
-
 SMART_ID_ENABLED = True
-SMART_ID_SERVICE_NAME = 'DEMO'
-SMART_ID_SERVICE_UUID = '00000000-0000-0000-0000-000000000000'
-SMART_ID_TEST_MODE = True
 
 # ***** End of Esteid service settings ******
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 # also check .travis.yml
 envlist =
     py36-django111
-    {py36,py37,py38}-django20
-    {py36,py37,py38}-django21
-    {py36,py37,py38}-django30
+    py37-django21
+    {py36,py38}-{django20,django30}
 
 [travis:env]
 DJANGO =
@@ -33,24 +32,5 @@ deps=
     django30: djangorestframework==3.12.*
     django30: Django>=3.0
 
-;[testenv:py36-django20]
-;deps=
-;    -rrequirements-base.txt
-;    -rrequirements-test.txt
-;    Django==2.0.*
-;    djangorestframework==3.9.*
-;
-;[testenv:py38-django30]
-;deps=
-;    -rrequirements-base.txt
-;    -rrequirements-test.txt
-;    Django>=3
-;    djangorestframework==3.12.*
-
 [testenv:py37-django21]
 commands = make test-full
-;deps=
-;    -rrequirements-base.txt
-;    -rrequirements-test.txt
-;    Django>=2.1.2,<2.2
-;    djangorestframework==3.9.*


### PR DESCRIPTION
* Added module `esteid.settings` where all possible settings for `django-esteid` are collected.
  This module is a single configuration entry point.
* Added more tests that focus on configuration.
* Set MobileID/SmartID defaults to demo so that explicit demo credentials are not necessary if TEST_MODE is on.

Also:

* removed several (precisely, 4) test environment configurations to speed up builds, because Travis is slow.
  It seems unlikely that code may break on one Python version while it
  doesn't break on both previous and next versions of it. (Same for Django)