### PR TITLE
Add eligibility check of signing party

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ clean-pyc:  ## Clean pyc files
 
 .PHONY:
 lint:  ## Run python linters
-	black --check $(PROJECT)
-	isort --check-only --project=$(PROJECT) $(PROJECT)
+	black --check .
+	isort --check-only --project=$(PROJECT) .
 	flake8 $(PROJECT)
 
 .PHONY:
@@ -58,5 +58,5 @@ coverage:  ## Run coverage
 
 .PHONY:
 fmt:  ## Format python code
-	black $(PROJECT)
-	isort --project=$(PROJECT) $(PROJECT)
+	black .
+	isort --project=$(PROJECT) .

--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,8 @@ import pytest
 
 from django.test import override_settings
 
+import pyasice
+
 import esteid.settings
 
 
@@ -142,14 +144,25 @@ def static_certificate():
 @pytest.fixture()
 def signed_container_file():
     """A real container signed via the Demo MobileID service with a test account"""
-    with open(Path(__file__).parent / "files" / "signed-test-mobileid-ee.asice", "rb") as f:
+    with open(Path(__file__).parent / "esteid" / "tests" / "files" / "signed-test-mobileid-ee.asice", "rb") as f:
         yield f
 
 
-@contextmanager
-def override_esteid_settings(**kwargs):
-    with override_settings(**kwargs):
-        importlib.reload(esteid.settings)
-        yield
+@pytest.fixture()
+def signed_container(signed_container_file):
+    """A handle to the signed container"""
+    with pyasice.Container(signed_container_file) as f:
+        yield f
 
-    importlib.reload(esteid.settings)
+
+@pytest.fixture()
+def override_esteid_settings():
+    @contextmanager
+    def wrapped(**kwargs):
+        with override_settings(**kwargs):
+            importlib.reload(esteid.settings)
+            yield
+
+        importlib.reload(esteid.settings)
+
+    return wrapped

--- a/esteid/exceptions.py
+++ b/esteid/exceptions.py
@@ -183,3 +183,14 @@ class UserTimeout(EsteidError):
     status = HTTPStatus.CONFLICT
 
     default_message = _("The signing operation timed out.")
+
+
+class AlreadySignedByUser(InvalidParameters):
+    """The container has been already signed by the same party.
+
+    The class is based on InvalidParameters so that such errors are not logged.
+    """
+
+    status = HTTPStatus.CONFLICT
+
+    default_message = _("The container has been already signed by the user.")

--- a/esteid/flowtest/views.py
+++ b/esteid/flowtest/views.py
@@ -31,7 +31,6 @@ class BaseMethods:
         return []
 
     def save_container(self, container: Container, *args, **kwargs):
-        # UploadedFile(container, "signed_document.doc", Container.MIME_TYPE)
         with NamedTemporaryFile("wb", delete=False) as f:
             f.write(container.finalize().getbuffer())
         self.request.session["__ddoc_container_file"] = f.name

--- a/esteid/idcard/test_idcardsigner.py
+++ b/esteid/idcard/test_idcardsigner.py
@@ -1,0 +1,56 @@
+import binascii
+from unittest.mock import Mock, patch
+
+import pytest
+
+from esteid.exceptions import InvalidParameter
+from esteid.idcard import IdCardSigner
+
+
+@pytest.fixture()
+def idcardsigner():
+    signer = IdCardSigner({}, initial=True)
+    mock_container = Mock(name="mock_container")
+    with patch.object(signer, "open_container", return_value=mock_container), patch.object(signer, "save_session_data"):
+        mock_container.prepare_signature.return_value = mock_xml_sig = Mock(name="mock_xml_sig")
+        mock_xml_sig.digest.return_value = b"some binary digest"
+
+        yield signer
+
+
+def test_idcardsigner_certificate(static_certificate):
+    signer = IdCardSigner({}, initial=True)
+    signer.setup({"certificate": binascii.b2a_hex(static_certificate)})
+
+    assert signer.id_code == "11702020200"
+
+    with pytest.raises(InvalidParameter, match="Missing required parameter 'certificate'"):
+        signer.setup({})
+
+    with pytest.raises(InvalidParameter, match="Failed to decode"):
+        signer.setup({"certificate": b"something not hex-encoded"})
+
+    with pytest.raises(InvalidParameter, match="supported certificate format"):
+        signer.setup({"certificate": binascii.b2a_hex(b"this is not a certificate")})
+
+
+def test_idcardsigner_prepare(idcardsigner, static_certificate):
+    idcardsigner.setup({"certificate": binascii.b2a_hex(static_certificate)})
+
+    result = idcardsigner.prepare(None, [])
+
+    idcardsigner.open_container.assert_called_once_with(None, [])
+    container = idcardsigner.open_container(...)
+
+    container.prepare_signature.assert_called_once_with(static_certificate)
+
+    xml_sig = idcardsigner.open_container().prepare_signature(...)
+    assert xml_sig._mock_name == "mock_xml_sig"
+
+    idcardsigner.save_session_data.assert_called_once_with(
+        digest=xml_sig.digest(),
+        container=container,
+        xml_sig=xml_sig,
+    )
+
+    assert result == {"digest": binascii.b2a_hex(xml_sig.digest()).decode()}

--- a/esteid/mobileid/tests/conftest.py
+++ b/esteid/mobileid/tests/conftest.py
@@ -4,7 +4,6 @@ import hashlib
 import pytest
 
 from esteid.constants import HASH_SHA512, MOBILE_ID_DEMO_SERVICE_NAME, MOBILE_ID_DEMO_SERVICE_UUID, MOBILE_ID_DEMO_URL
-from esteid.tests.conftest import *  # noqa: F401, F403 -- Force pytest to load fixtures from the common conftest
 
 from ..base import MobileIDService
 from ..constants import EndResults

--- a/esteid/mobileid/tests/test_base.py
+++ b/esteid/mobileid/tests/test_base.py
@@ -4,8 +4,6 @@ import requests_mock
 from django.core.exceptions import ImproperlyConfigured
 from requests.exceptions import ConnectTimeout
 
-from esteid.tests.conftest import override_esteid_settings
-
 from ...constants import MOBILE_ID_DEMO_URL, MOBILE_ID_LIVE_URL
 from ...exceptions import EsteidError, InvalidCredentials, OfflineError, UpstreamServiceError
 from .. import MobileIDError
@@ -61,7 +59,7 @@ def test_mobileid_translated_service(i18n_demo_mid_api):
     assert i18n_demo_mid_api.api_root == MOBILE_ID_DEMO_URL
 
 
-def test_mobileid_translated_service_test_mode_off(i18n_demo_mid_api):
+def test_mobileid_translated_service_test_mode_off(i18n_demo_mid_api, override_esteid_settings):
     with override_esteid_settings(
         MOBILE_ID_TEST_MODE=False,
         MOBILE_ID_SERVICE_UUID="00000000-0000-0000-0000-000000000000",
@@ -73,7 +71,7 @@ def test_mobileid_translated_service_test_mode_off(i18n_demo_mid_api):
         assert service.rp_name == "test"
 
 
-def test_mobileid_translated_service_requires_creds_for_live():
+def test_mobileid_translated_service_requires_creds_for_live(override_esteid_settings):
     with override_esteid_settings(MOBILE_ID_TEST_MODE=False):
         with pytest.raises(ImproperlyConfigured, match="MOBILE_ID_SERVICE_NAME and MOBILE_ID_SERVICE_UUID"):
             TranslatedMobileIDService.get_instance()

--- a/esteid/settings.py
+++ b/esteid/settings.py
@@ -61,3 +61,6 @@ TSA_URL = getattr(settings, "ESTEID_TSA_URL", constants.TSA_DEMO_URL if ESTEID_D
 
 # Used exclusively by esteid.middleware.BaseIdCardMiddleware
 ESTEID_OCSP_RESPONDER_CERTIFICATE_PATH = getattr(settings, "ESTEID_OCSP_RESPONDER_CERTIFICATE_PATH", None)
+
+# Whether one signatory can sign the same container more than once
+ESTEID_ALLOW_ONE_PARTY_SIGN_TWICE = getattr(settings, "ESTEID_ALLOW_ONE_PARTY_SIGN_TWICE", True)

--- a/esteid/signing/signer.py
+++ b/esteid/signing/signer.py
@@ -56,6 +56,9 @@ class Signer:
     # timeout in seconds, after which a fresh session can be started even if old session data is present.
     SESSION_VALIDITY_TIMEOUT = 1  # 60 * 2
 
+    # the signing party's ID code, public attribute/property for use in checks etc.
+    id_code: str
+
     # Abstract Methods
 
     def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:

--- a/esteid/signing/tests/test_views.py
+++ b/esteid/signing/tests/test_views.py
@@ -1,0 +1,46 @@
+from unittest.mock import Mock
+
+import pytest
+
+from esteid.exceptions import AlreadySignedByUser
+from esteid.types import Signer as SignerData
+
+from ..views import SignViewMixin
+
+
+@pytest.fixture()
+def signatory_id_code(signed_container):
+    signature = next(signed_container.iter_signatures())
+    subject_cert = signature.get_certificate()
+    signatory = SignerData.from_certificate(subject_cert)
+    return signatory.id_code
+
+
+@pytest.mark.parametrize(
+    "container,allow_sign_many,result",
+    [
+        pytest.param(None, True, None, id="No container, allowed - OK"),
+        pytest.param(None, False, None, id="No container, not allowed - OK"),
+        pytest.param(True, True, None, id="Container, allowed - OK"),
+        pytest.param(True, False, AlreadySignedByUser, id="Container, not allowed - ERROR"),
+    ],
+)
+def test_signing_views_check_eligibility(
+    signatory_id_code, container, allow_sign_many, result, signed_container, override_esteid_settings
+):
+    if container:
+        container = signed_container
+
+    signer = Mock(id_code=signatory_id_code)
+    signer_not_signatory = Mock(id_code="12345678912")
+    view = SignViewMixin()
+
+    with override_esteid_settings(ESTEID_ALLOW_ONE_PARTY_SIGN_TWICE=allow_sign_many):
+        # Signing by a different party should always succeed
+        view.check_eligibility(signer_not_signatory, container)
+
+        if result is AlreadySignedByUser:
+            with pytest.raises(AlreadySignedByUser):
+                view.check_eligibility(signer, container)
+        else:
+            view.check_eligibility(signer, container)

--- a/esteid/smartid/tests/conftest.py
+++ b/esteid/smartid/tests/conftest.py
@@ -2,8 +2,6 @@ import base64
 
 import pytest
 
-from esteid.tests.conftest import *  # noqa: F401, F403  -- force pytest to use fixtures from that file
-
 from ...constants import HASH_SHA512, SMART_ID_DEMO_SERVICE_NAME, SMART_ID_DEMO_SERVICE_UUID, SMART_ID_DEMO_URL
 from ...util import generate_hash
 from ..base import SmartIDService

--- a/esteid/smartid/tests/test_base.py
+++ b/esteid/smartid/tests/test_base.py
@@ -5,8 +5,6 @@ import requests_mock
 from django.core.exceptions import ImproperlyConfigured
 from requests.exceptions import ConnectTimeout
 
-from esteid.tests.conftest import override_esteid_settings
-
 from ...constants import SMART_ID_DEMO_URL, SMART_ID_LIVE_URL
 from ...exceptions import (
     BadRequest,
@@ -68,7 +66,7 @@ def test_smartid_translated_service(i18n_demo_api):
     assert i18n_demo_api.api_root == SMART_ID_DEMO_URL
 
 
-def test_smartid_translated_service_test_mode_off():
+def test_smartid_translated_service_test_mode_off(override_esteid_settings):
     with override_esteid_settings(
         SMART_ID_TEST_MODE=False,
         SMART_ID_SERVICE_UUID="00000000-0000-0000-0000-000000000000",
@@ -80,7 +78,7 @@ def test_smartid_translated_service_test_mode_off():
         assert service.rp_name == "test"
 
 
-def test_smartid_translated_service_requires_creds_for_live():
+def test_smartid_translated_service_requires_creds_for_live(override_esteid_settings):
     with override_esteid_settings(SMART_ID_TEST_MODE=False):
         with pytest.raises(ImproperlyConfigured, match="SMART_ID_SERVICE_NAME and SMART_ID_SERVICE_UUID"):
             TranslatedSmartIDService.get_instance()

--- a/esteid/tests/test_context_processors.py
+++ b/esteid/tests/test_context_processors.py
@@ -1,8 +1,7 @@
 from esteid import context_processors
-from esteid.tests.conftest import override_esteid_settings
 
 
-def test_context_processors_esteid_services():
+def test_context_processors_esteid_services(override_esteid_settings):
     test_settings = {
         "ESTEID_DEMO": 1,
         "ID_CARD_ENABLED": 2,

--- a/esteid/tests/test_types.py
+++ b/esteid/tests/test_types.py
@@ -1,7 +1,14 @@
+import json
+
+import attr
+import oscrypto.asymmetric
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+
 import pyasice
 
 from esteid.compat import container_info
-from esteid.types import DataFileInfo, SignedDocInfo
+from esteid.types import Certificate, DataFileInfo, SignedDocInfo, Signer
 
 
 def test_signeddocinfo_from_dict(signed_doc_dict):
@@ -40,3 +47,46 @@ def test_signeddocinfo_from_container(signed_container_file):
 
     assert len(data.data_file_info) == 1
     assert data.data_file_info[0].filename == "test.txt"
+
+
+@pytest.mark.parametrize('cert_type', ["bytes", "asn1", "oscrypto"])
+def test_certificate_from_cert(static_certificate, cert_type):
+    if cert_type == "bytes":
+        cert = static_certificate
+    else:
+        cert = oscrypto.asymmetric.load_certificate(static_certificate)
+        if cert_type == "asn1":
+            cert = cert.asn1
+
+    cert_data = Certificate.from_certificate(cert)
+    assert cert_data.issuer_serial == "116050271893176812114901422365303754679"
+    assert cert_data.issuer == (
+        "Common Name: TEST of NQ-SK 2016, "
+        "Organization Identifier: NTREE-10747013, "
+        "Organization: AS Sertifitseerimiskeskus, Country: EE"
+    )
+    assert cert_data.valid_from.isoformat() == "2017-02-02T09:14:37+00:00"
+    assert cert_data.valid_to.isoformat() == "2022-02-01T21:59:59+00:00"
+    assert cert_data.subject == "SMART-ID,HELLO,PNOEE-11702020200"
+
+
+@pytest.mark.parametrize('cert_type', ["bytes", "asn1", "oscrypto"])
+def test_signer_data_from_oscrypto_cert(static_certificate, cert_type):
+    if cert_type == "bytes":
+        cert = static_certificate
+    else:
+        cert = oscrypto.asymmetric.load_certificate(static_certificate)
+        if cert_type == "asn1":
+            cert = cert.asn1
+
+    signer_data = Signer.from_certificate(cert)
+    assert signer_data.full_name == "HELLO SMART-ID"
+    assert signer_data.id_code == "11702020200"
+    assert isinstance(signer_data.certificate, Certificate)
+
+
+def test_signer_data_to_json(static_certificate):
+    signer_data = Signer.from_certificate(static_certificate)
+
+    output = json.dumps(attr.asdict(signer_data), cls=DjangoJSONEncoder)
+    assert Signer.from_dict(json.loads(output)) == signer_data

--- a/esteid/tests/test_types.py
+++ b/esteid/tests/test_types.py
@@ -1,8 +1,9 @@
 import json
 
+import pytest
+
 import attr
 import oscrypto.asymmetric
-import pytest
 from django.core.serializers.json import DjangoJSONEncoder
 
 import pyasice
@@ -49,7 +50,7 @@ def test_signeddocinfo_from_container(signed_container_file):
     assert data.data_file_info[0].filename == "test.txt"
 
 
-@pytest.mark.parametrize('cert_type', ["bytes", "asn1", "oscrypto"])
+@pytest.mark.parametrize("cert_type", ["bytes", "asn1", "oscrypto"])
 def test_certificate_from_cert(static_certificate, cert_type):
     if cert_type == "bytes":
         cert = static_certificate
@@ -70,7 +71,7 @@ def test_certificate_from_cert(static_certificate, cert_type):
     assert cert_data.subject == "SMART-ID,HELLO,PNOEE-11702020200"
 
 
-@pytest.mark.parametrize('cert_type', ["bytes", "asn1", "oscrypto"])
+@pytest.mark.parametrize("cert_type", ["bytes", "asn1", "oscrypto"])
 def test_signer_data_from_oscrypto_cert(static_certificate, cert_type):
     if cert_type == "bytes":
         cert = static_certificate

--- a/esteid/types.py
+++ b/esteid/types.py
@@ -3,8 +3,8 @@ from typing import List, TYPE_CHECKING, Union
 
 import attr
 import pytz
-
 from oscrypto.asymmetric import load_certificate
+
 
 if TYPE_CHECKING:
     from oscrypto.asymmetric import Certificate as OsCryptoCertificate

--- a/esteid/types.py
+++ b/esteid/types.py
@@ -1,7 +1,14 @@
 from datetime import datetime
-from typing import List
+from typing import List, TYPE_CHECKING, Union
 
 import attr
+import pytz
+
+from oscrypto.asymmetric import load_certificate
+
+if TYPE_CHECKING:
+    from oscrypto.asymmetric import Certificate as OsCryptoCertificate
+    from asn1crypto.cms import Certificate as Asn1CryptoCertificate
 
 import pyasice
 
@@ -31,11 +38,11 @@ class CertificatePolicy(FromDictMixin):
 
 @attr.s
 class Certificate(FromDictMixin):
-    valid_from = attr.ib()  # this might be a timestamp
-    issuer_serial = attr.ib()
     issuer = attr.ib()
-    valid_to = attr.ib()  # this might be a timestamp
+    issuer_serial = attr.ib()
     subject = attr.ib()
+    valid_from: datetime = attr.ib(converter=convert_time)
+    valid_to: datetime = attr.ib(converter=convert_time)
 
     policies = attr.ib(
         default=attr.Factory(list),
@@ -45,6 +52,27 @@ class Certificate(FromDictMixin):
         ],
         converter=get_typed_list_converter(CertificatePolicy),
     )
+
+    @classmethod
+    def from_certificate(cls, cert: "Union[bytes, Asn1CryptoCertificate, OsCryptoCertificate]"):
+        if isinstance(cert, bytes):
+            cert = load_certificate(cert)
+        cert_asn1: "Asn1CryptoCertificate" = getattr(cert, "asn1", cert)
+        personal = cert_asn1.subject.native
+        issuer = cert_asn1["tbs_certificate"]["issuer"]
+        serial = cert_asn1["tbs_certificate"]["serial_number"].native
+
+        validity = cert_asn1["tbs_certificate"]["validity"].native
+        valid_from: datetime = validity["not_before"]
+        valid_to: datetime = validity["not_after"]
+
+        return cls(
+            issuer=issuer.human_friendly,
+            issuer_serial=str(serial),
+            subject=personal["common_name"],
+            valid_from=valid_from.replace(microsecond=0).astimezone(pytz.utc),
+            valid_to=valid_to.replace(microsecond=0).astimezone(pytz.utc),
+        )
 
 
 @attr.s
@@ -75,6 +103,33 @@ class Signer(FromDictMixin):
         kwargs["full_name"] = full_name
 
         return kwargs
+
+    @classmethod
+    def from_certificate(cls, cert: "Union[bytes, Asn1CryptoCertificate, OsCryptoCertificate]"):
+        """
+        Get personal info from an oscrypto/asn1crypto Certificate object
+
+        For a closer look at where the attributes come from:
+        asn1crypto.x509.NameType
+        """
+        if isinstance(cert, bytes):
+            cert = load_certificate(cert)
+        cert: "Asn1CryptoCertificate" = getattr(cert, "asn1", cert)
+        subject = cert.subject.native
+
+        # ID codes usually given as PNO{EE,LT,LV}-XXXXXX.
+        # LV ID codes contain a dash so we need to be careful about it.
+        id_code = subject["serial_number"]
+        if id_code.startswith("PNO"):
+            prefix, id_code = id_code.split("-", 1)
+
+        given_name = subject["given_name"]
+        surname = subject["surname"]
+        return cls(
+            certificate=Certificate.from_certificate(cert),
+            full_name=f"{given_name} {surname}",
+            id_code=id_code,
+        )
 
 
 @attr.s

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,7 @@
 import os
 import sys
 
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_settings")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,12 @@ exclude =
     build,
     dist,
     venv*
+    .venv*
 
 [tool:isort]
 skip_glob=
   venv/*
+  .venv/*
   migrations
 line_length=120
 atomic=true

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import esteid
 
+
 try:
     from setuptools import setup
 except ImportError:
@@ -10,36 +11,36 @@ except ImportError:
 
 version = esteid.__version__
 
-readme = open('README.md').read()
-requirements_base = open('requirements-base.txt').readlines()
-requirements = open('requirements.txt').readlines()
+readme = open("README.md").read()
+requirements_base = open("requirements-base.txt").readlines()
+requirements = open("requirements.txt").readlines()
 
 setup(
-    name='django-esteid',
+    name="django-esteid",
     version=version,
     description="""Django-esteid is a package that provides Esteid based authentication for your Django applications.""",
     long_description=readme,
-    long_description_content_type='text/markdown',
-    author='Thorgate',
-    author_email='jyrno@thorgate.eu',
-    url='https://github.com/thorgate/django-esteid',
+    long_description_content_type="text/markdown",
+    author="Thorgate",
+    author_email="jyrno@thorgate.eu",
+    url="https://github.com/thorgate/django-esteid",
     packages=[
-        'esteid',
+        "esteid",
     ],
     include_package_data=True,
-    install_requires=[line for line in requirements + requirements_base if line and not line.startswith(('#', '-'))],
+    install_requires=[line for line in requirements + requirements_base if line and not line.startswith(("#", "-"))],
     license="BSD",
     zip_safe=False,
-    keywords='esteid django',
+    keywords="esteid django",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 2 - Pre-Alpha",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,5 +1,6 @@
 import os
 
+
 # ****** Esteid service settings ******
 # Refer to esteid.settings for a comprehensive list of settings.
 
@@ -12,82 +13,78 @@ SMART_ID_ENABLED = True
 
 DEBUG = True
 
-SECRET_KEY = 'q^es5sedujo$g@%-d4tl9ws@z+#m1mab&sdr_5)r&a80_+kd@+'
+SECRET_KEY = "q^es5sedujo$g@%-d4tl9ws@z+#m1mab&sdr_5)r&a80_+kd@+"
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'db.sqlite',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "db.sqlite",
     }
 }
 
-ROOT_URLCONF = 'esteid.urls'
+ROOT_URLCONF = "esteid.urls"
 
 # Django pre-1.10 setting was MIDDLEWARE_CLASSES
 MIDDLEWARE = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
 ]
 
 INSTALLED_APPS = [
-    'django.contrib.sessions',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'rest_framework',
-    'esteid',
+    "django.contrib.sessions",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "rest_framework",
+    "esteid",
 ]
 
-if 'TOX_TESTS' not in os.environ:
+if "TOX_TESTS" not in os.environ:
     INSTALLED_APPS += [
         "sslserver",
     ]
 
 USE_TZ = True
 TZ = "UTC"
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.tz',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
-                'esteid.context_processors.esteid_services'
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
+                "esteid.context_processors.esteid_services",
             ],
-            'loaders': [
-                'django.template.loaders.app_directories.Loader',
+            "loaders": [
+                "django.template.loaders.app_directories.Loader",
             ],
         },
     },
 ]
 
 LOGGING = {
-    'version': 1,
-    'formatters': {
-        'verbose': {
-            'format': '%(asctime)s [%(levelname)s] %(name)s:%(lineno)d %(funcName)s - %(message)s'
-        }
-    },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'verbose',
+    "version": 1,
+    "formatters": {"verbose": {"format": "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d %(funcName)s - %(message)s"}},
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
         },
     },
-    'loggers': {
-        '': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
+    "loggers": {
+        "": {
+            "handlers": ["console"],
+            "level": "DEBUG",
         },
-        'esteid': {'handlers': [], 'propagate': True},
-        'django': {'handlers': [], 'propagate': True},
-        'django.request': {'handlers': [], 'propagate': True},
-        'django.security': {'handlers': [], 'propagate': True},
-    }
+        "esteid": {"handlers": [], "propagate": True},
+        "django": {"handlers": [], "propagate": True},
+        "django.request": {"handlers": [], "propagate": True},
+        "django.security": {"handlers": [], "propagate": True},
+    },
 }


### PR DESCRIPTION
Add eligibility check of signing party

In the SignViewMixin, added the `check_eligibility` method
that inspects the current signatories of a container and
raises an error of type `AlreadySignedByUser` if the initiator of the signing process
has already signed this container.

Introduced a setting that disables this check.

As prerequisites,
* added to data classes `Signer`, `Certificate` the `from_certificate` method
  that loads the class's data from a certificate;
* made use of the `Signer` dataclass in the `IdCardSigner` class 
  to inspect the received certificate and obtain the signing party's ID code from it;

As minor improvements,
* made error handling in the SignViewMixin's post/patch methods more comprehensible;
* added `ValidationError` propagation and special handling in the placee mentioned above;
* added some docs and tests;
* moved the `esteid/tests/conftest.py` file to project root so that `pytest` autodiscovers it;
* made `override_esteid_settings` into a fixture;
* added black & isort checks over the python files in project root.