### PR TITLE
Add a method for user cancel handling customization

### DIFF
--- a/esteid/exceptions.py
+++ b/esteid/exceptions.py
@@ -48,6 +48,8 @@ class ActionInProgress(EsteidError):
 
     status = HTTPStatus.ACCEPTED
 
+    default_message = _("Operation is in progress.")
+
     def __init__(self, message=None, data: dict = None):
         super().__init__(message)
         self.data = data or {}
@@ -66,6 +68,10 @@ class UpstreamServiceError(EsteidError):
 
     default_message = _("The {service} service reported a failure.")
 
+    def __init__(self, message=None, *, service, **kwargs):
+        super().__init__(message)
+        self.kwargs = {"service": service, **kwargs}
+
 
 class OfflineError(UpstreamServiceError):
     default_message = _("The {service} service is unavailable at the moment. Please try again later.")
@@ -77,6 +83,10 @@ class PermissionDenied(UpstreamServiceError):
     """
 
     default_message = _("Operation with user certificate level ADVANCED not allowed.")
+
+    def __init__(self, message=None, **kwargs):
+        kwargs.setdefault("service", "smartid")
+        super().__init__(message, **kwargs)
 
 
 class UnsupportedClientImplementation(UpstreamServiceError):

--- a/esteid/signing/README.md
+++ b/esteid/signing/README.md
@@ -167,6 +167,17 @@ The native Django and DRF `ValidationError`s can be used when the error is relat
 for logging. Finally, `Http404` fits when the object to sign can not be found, and can be raised 
 from the `get_container()` or `get_files_to_sign` methods.
 
+### Handling of user cancellation of signing
+
+When an additional action is necessary on user cancel, override the `handle_user_cancel` method of the signing view:
+
+```python
+class YourSignView(SignViewDjangoMixin, View):
+    ...
+    def handle_user_cancel(self):
+        ...
+``` 
+
 ### Signing party's eligibility
 
 Technically it is possible for a signing party to sign a container multiple times. The XAdES standard doesn't seem to

--- a/esteid/signing/tests/test_views.py
+++ b/esteid/signing/tests/test_views.py
@@ -1,8 +1,19 @@
-from unittest.mock import Mock
+import json
+from http import HTTPStatus
+from unittest.mock import Mock, patch
 
 import pytest
 
-from esteid.exceptions import AlreadySignedByUser
+from esteid.exceptions import (
+    ActionInProgress,
+    AlreadySignedByUser,
+    CanceledByUser,
+    EsteidError,
+    InvalidParameters,
+    OfflineError,
+    UpstreamServiceError,
+    UserNotRegistered,
+)
 from esteid.types import Signer as SignerData
 
 from ..views import SignViewMixin
@@ -14,6 +25,23 @@ def signatory_id_code(signed_container):
     subject_cert = signature.get_certificate()
     signatory = SignerData.from_certificate(subject_cert)
     return signatory.id_code
+
+
+@pytest.fixture()
+def signer_class():
+    signer_class = Mock(name="signer class")
+    signer_class.start_session.return_value = signer_class()
+    signer_class.load_session.return_value = signer_class()
+    return signer_class
+
+
+@pytest.fixture()
+def signing_view(signer_class):
+    the_view = SignViewMixin()
+    with patch.object(the_view, "select_signer_class", return_value=signer_class), patch.object(
+        the_view, "get_container"
+    ):
+        yield the_view
 
 
 @pytest.mark.parametrize(
@@ -44,3 +72,97 @@ def test_signing_views_check_eligibility(
                 view.check_eligibility(signer, container)
         else:
             view.check_eligibility(signer, container)
+
+
+def test_signing_views_canceled_by_user(signing_view, signer_class):
+    signer_class().finalize.side_effect = CanceledByUser
+
+    with patch.object(signing_view, "handle_user_cancel"):
+        result = signing_view.patch(Mock())
+
+        signing_view.handle_user_cancel.assert_called_once()
+
+        assert result.status_code == CanceledByUser.status
+        assert json.loads(result.content) == {
+            "status": "error",
+            "error": "CanceledByUser",
+            "message": str(CanceledByUser.default_message),
+        }
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OfflineError(service="service"),
+        UpstreamServiceError(service="service"),
+    ],
+)
+def test_signing_views_esteid_error_handling_finalize(error: EsteidError, signing_view, signer_class):
+    signer_class().finalize.side_effect = error
+
+    result = signing_view.patch(Mock())
+
+    assert result.status_code == error.status
+    assert json.loads(result.content) == {
+        "status": "error",
+        "error": error.__class__.__name__,
+        "message": str(error.default_message).format(service="service"),
+    }
+
+
+def test_signing_views_exception_handling_finalize(signing_view, signer_class):
+    signer_class().finalize.side_effect = Exception("unhandled")
+
+    result = signing_view.patch(Mock())
+
+    assert result.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert json.loads(result.content) == {
+        "status": "error",
+        "error": "Internal error",
+        "message": "Internal server error",
+    }
+
+
+def test_signing_views_action_in_progress(signing_view, signer_class):
+    progress_data = {"verification_code": 1111}
+    signer_class().finalize.side_effect = ActionInProgress("In progress", data=progress_data)
+
+    result = signing_view.patch(Mock())
+
+    assert result.status_code == ActionInProgress.status == HTTPStatus.ACCEPTED
+    assert json.loads(result.content) == {"status": "pending", **progress_data}
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        InvalidParameters(),
+        OfflineError(service="service"),
+        UserNotRegistered(),
+        UpstreamServiceError(service="service"),
+    ],
+)
+def test_signing_views_esteid_error_handling_prepare(error: EsteidError, signing_view, signer_class):
+    signer_class().prepare.side_effect = error
+
+    result = signing_view.post(Mock())
+
+    assert result.status_code == error.status
+    assert json.loads(result.content) == {
+        "status": "error",
+        "error": error.__class__.__name__,
+        "message": str(error.default_message).format(service="service"),  # .format(): unused arguments are ignored
+    }
+
+
+def test_signing_views_exception_handling_prepare(signing_view, signer_class):
+    signer_class().prepare.side_effect = Exception("unhandled")
+
+    result = signing_view.post(Mock())
+
+    assert result.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert json.loads(result.content) == {
+        "status": "error",
+        "error": "Internal error",
+        "message": "Internal server error",
+    }

--- a/esteid/signing/views.py
+++ b/esteid/signing/views.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext
 import pyasice
 
 from esteid import settings
-from esteid.exceptions import ActionInProgress, AlreadySignedByUser, EsteidError, InvalidParameters
+from esteid.exceptions import ActionInProgress, AlreadySignedByUser, CanceledByUser, EsteidError, InvalidParameters
 from esteid.types import Signer as SignerData
 
 from .signer import Signer
@@ -153,8 +153,14 @@ class SignViewMixin:
     def report_error(self, e: EsteidError):
         return JsonResponse({"status": self.Status.ERROR, **e.get_user_error()}, status=e.status)
 
+    def handle_user_cancel(self):
+        pass
+
     def handle_errors(self, e: Exception, stage="start"):
         if isinstance(e, EsteidError):
+            if isinstance(e, CanceledByUser):
+                self.handle_user_cancel()
+
             # Do not log user input related errors
             if not isinstance(e, InvalidParameters):
                 logger.exception("Failed to %s signing session.", stage)

--- a/esteid/smartid/base.py
+++ b/esteid/smartid/base.py
@@ -384,7 +384,7 @@ class SmartIDService(BaseSKService):
             elif end_result not in EndResults.ALL:
                 raise SmartIDError(f"Unexpected end result {end_result}")
 
-            raise UpstreamServiceError(end_result)
+            raise UpstreamServiceError(end_result, service=self.NAME)
 
         return data
 


### PR DESCRIPTION
Added the `handle_user_cancel` method to `SignViewMixin`, that can be overridden to customize handling of signing process cancellations.

Also added some more `SignViewMixin` tests and fixed a potential issue with invalid arguments to an exception.