### PR TITLE
Fix an issue with invalid container parameter being passed to `check_eligibility`

### DIFF
--- a/esteid/flowtest/signer.py
+++ b/esteid/flowtest/signer.py
@@ -1,15 +1,15 @@
 from typing import List
 
-from pyasice import XmlSignature
+import pyasice
 
 from esteid.exceptions import InvalidParameter
 from esteid.signing import Container, DataFile, Signer
 
 
 class MySigner(Signer):
-    def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:
-        container = self.open_container(container_file, files)
-        xml_sig = XmlSignature.create()
+    def prepare(self, container: pyasice.Container = None, files: List[DataFile] = None) -> dict:
+        container = self.open_container(container, files)
+        xml_sig = pyasice.XmlSignature.create()
 
         self.save_session_data(digest=b"test", container=container, xml_sig=xml_sig)
 

--- a/esteid/idcard/signer.py
+++ b/esteid/idcard/signer.py
@@ -55,8 +55,8 @@ class IdCardSigner(Signer):
 
         self.certificate = certificate
 
-    def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:
-        container = self.open_container(container_file, files)
+    def prepare(self, container: pyasice.Container = None, files: List[DataFile] = None) -> dict:
+        container = self.open_container(container, files)
         xml_sig = container.prepare_signature(self.certificate)
 
         # Note: uses default digest algorithm (sha256)

--- a/esteid/mobileid/signer.py
+++ b/esteid/mobileid/signer.py
@@ -70,8 +70,8 @@ class MobileIdSigner(Signer):
         self.phone_number = user_input.phone_number
         self.language = user_input.language
 
-    def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:
-        container = self.open_container(container_file, files)
+    def prepare(self, container=None, files: List[DataFile] = None) -> dict:
+        container = self.open_container(container, files)
 
         service = TranslatedMobileIDService.get_instance()
 

--- a/esteid/signing/signer.py
+++ b/esteid/signing/signer.py
@@ -2,7 +2,7 @@ import logging
 import os
 from tempfile import NamedTemporaryFile
 from time import time
-from typing import BinaryIO, Dict, List, Type, Union
+from typing import Dict, List, Type
 
 from esteid_certificates import get_certificate
 
@@ -61,7 +61,7 @@ class Signer:
 
     # Abstract Methods
 
-    def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:
+    def prepare(self, container: Container = None, files: List[DataFile] = None) -> dict:
         """
         Abstract method. Prepares the container, either from an existing one or from files.
 
@@ -200,12 +200,12 @@ class Signer:
             pass
 
     @staticmethod
-    def open_container(container_file: Union[str, BinaryIO] = None, files: List[DataFile] = None) -> Container:
-        if container_file:
-            if isinstance(container_file, str):
-                container = Container.open(container_file)
-            else:
-                container = Container(container_file)
+    def open_container(container: Container = None, files: List[DataFile] = None) -> Container:
+        if container:
+            if not isinstance(container, Container):
+                raise ValueError(
+                    f"Expected container to be a pyasice.Container instance, got {container.__class__.__name__}"
+                )
         elif files:
             container = Container()
             for f in files:

--- a/esteid/smartid/signer.py
+++ b/esteid/smartid/signer.py
@@ -65,8 +65,8 @@ class SmartIdSigner(Signer):
         self.id_code = user_input.id_code
         self.country = user_input.country
 
-    def prepare(self, container_file=None, files: List[DataFile] = None) -> dict:
-        container = self.open_container(container_file, files)
+    def prepare(self, container: Container = None, files: List[DataFile] = None) -> dict:
+        container = self.open_container(container, files)
 
         service = TranslatedSmartIDService.get_instance()
 


### PR DESCRIPTION
As it unwound a chain of different inconsistencies and potential problems,
some APIs have changed.
* `Signer.prepare()` now accepts a `pyasice.Container` instance instead of generics;
* `Signer.open_container()` now accepts a `pyasice.Container` instance instead of generics
  and performs a type check;
* `SignViewMixin.get_container()` may return a `pyasice.Container`
* `SignViewMixin.start_session()` handles the `SignViewMixin.get_container()` return value,
  promoting it to a `pyasice.Container` if necessary
* the concrete `Signer` implementations were updated to reflect these API changes.