### PR TITLE
Make MobileID phone number check optional and its regexp configurable

### DIFF
--- a/esteid/mobileid/tests/test_types.py
+++ b/esteid/mobileid/tests/test_types.py
@@ -1,0 +1,57 @@
+import importlib
+import re
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "phone_number_regexp,compiled,result",
+    [
+        pytest.param(None, re.compile(r"^\+37[02]\d{7,8}$"), True, id="Not set"),
+        pytest.param("", "", True, id="Empty string"),
+        pytest.param(r"^xxx$", re.compile(r"^xxx$"), False, id="Arbitrary regexp"),
+    ],
+)
+def test_mobile_id_phone_number_regexp(
+    override_esteid_settings, phone_number_regexp, compiled, result, MID_DEMO_PIN_EE_OK, MID_DEMO_PHONE_EE_OK
+):
+    import esteid.mobileid.types
+
+    with override_esteid_settings(MOBILE_ID_PHONE_NUMBER_REGEXP=phone_number_regexp):
+        import esteid.settings
+
+        assert esteid.settings.MOBILE_ID_PHONE_NUMBER_REGEXP == compiled
+
+        importlib.reload(esteid.mobileid.types)
+        ui = esteid.mobileid.types.UserInput(id_code=MID_DEMO_PIN_EE_OK, phone_number=MID_DEMO_PHONE_EE_OK)
+        assert ui.is_valid(raise_exception=False) == result
+
+    # Restore the module as it was before override
+    importlib.reload(esteid.mobileid.types)
+
+
+@pytest.mark.parametrize(
+    "phone_number_regexp, phone, result",
+    [
+        pytest.param(None, "+18005551234", False, id="Not set"),
+        pytest.param("", "+18005551234", True, id="Empty string"),
+        pytest.param(r"^xxx$", "+18005551234", False, id="Arbitrary regexp not matching"),
+        pytest.param(r"^\+1800\d+$", "+18005551234", True, id="Arbitrary regexp matching"),
+    ],
+)
+def test_mobile_id_phone_number_regexp__error(
+    override_esteid_settings,
+    phone_number_regexp,
+    phone,
+    result,
+    MID_DEMO_PIN_EE_OK,
+):
+    import esteid.mobileid.types
+
+    with override_esteid_settings(MOBILE_ID_PHONE_NUMBER_REGEXP=phone_number_regexp):
+        importlib.reload(esteid.mobileid.types)
+        ui = esteid.mobileid.types.UserInput(id_code=MID_DEMO_PIN_EE_OK, phone_number=phone)
+        assert ui.is_valid(raise_exception=False) == result
+
+    # Restore the module as it was before override
+    importlib.reload(esteid.mobileid.types)

--- a/esteid/settings.py
+++ b/esteid/settings.py
@@ -1,6 +1,8 @@
 """
 This module contains all configuration settings for django-esteid.
 """
+import re
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -28,6 +30,20 @@ MOBILE_ID_TEST_MODE = getattr(settings, "MOBILE_ID_TEST_MODE", ESTEID_DEMO)
 MOBILE_ID_SERVICE_NAME = getattr(settings, "MOBILE_ID_SERVICE_NAME", None)
 MOBILE_ID_SERVICE_UUID = getattr(settings, "MOBILE_ID_SERVICE_UUID", None)
 MOBILE_ID_API_ROOT = getattr(settings, "MOBILE_ID_API_ROOT", None)
+
+# Mobile phone number sanity check: optional, a regexp pattern. If not set or None, defaults to a simple regexp.
+# To disable checks, set it to empty string.
+_MOBILE_ID_PHONE_NUMBER_REGEXP = getattr(settings, "MOBILE_ID_PHONE_NUMBER_REGEXP", None)
+if _MOBILE_ID_PHONE_NUMBER_REGEXP is None:
+    # Mobile ID supports Estonian and Lithuanian phones
+    _MOBILE_ID_PHONE_NUMBER_REGEXP = re.compile(r"^\+37[02]\d{7,8}$")
+elif _MOBILE_ID_PHONE_NUMBER_REGEXP:
+    try:
+        _MOBILE_ID_PHONE_NUMBER_REGEXP = re.compile(_MOBILE_ID_PHONE_NUMBER_REGEXP)
+    except ValueError as e:
+        raise ImproperlyConfigured("MOBILE_ID_PHONE_NUMBER_REGEXP must be a valid regular expression") from e
+
+MOBILE_ID_PHONE_NUMBER_REGEXP = _MOBILE_ID_PHONE_NUMBER_REGEXP
 
 _MOBILE_ID_DEFAULT_LANGUAGE = getattr(settings, "MOBILE_ID_DEFAULT_LANGUAGE", None)
 


### PR DESCRIPTION
This would leave a possibility to skip the phone number check to the library users or configure the regular expression used for it.