### PR TITLE
Release 3.1.post1

### DIFF
--- a/esteid/__init__.py
+++ b/esteid/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "3.1"
+__version__ = "3.1.post1"


### PR DESCRIPTION
There was an accidentally uploaded "release 3.1" package which was actually alpha. Having to re-tag it as -post1 now.